### PR TITLE
[week2] 2차 세미나 정규 과제

### DIFF
--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	testImplementation 'io.rest-assured:rest-assured'
 
 	runtimeOnly('com.h2database:h2')
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
 	testImplementation 'io.rest-assured:rest-assured'
+
+	runtimeOnly('com.h2database:h2')
 }
 
 tasks.named('test') {

--- a/spring/src/main/java/org/sopt/spring/common/GlobalExceptionHandler.java
+++ b/spring/src/main/java/org/sopt/spring/common/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package org.sopt.spring.common;
+
+import org.sopt.spring.common.dto.ErrorMessage;
+import org.sopt.spring.common.dto.ErrorResponse;
+import org.sopt.spring.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import java.util.Objects;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e){
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(ErrorMessage.MEMBER_NOT_FOUND));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(),
+                Objects.requireNonNull(e.getBindingResult().getFieldError().getDefaultMessage())));
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/common/dto/ErrorMessage.java
+++ b/spring/src/main/java/org/sopt/spring/common/dto/ErrorMessage.java
@@ -1,0 +1,16 @@
+package org.sopt.spring.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorMessage {
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다"),
+    BLOG_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 블로그가 존재하지 않습니다")
+    ;
+    private final int status;
+    private final String message;
+}
+

--- a/spring/src/main/java/org/sopt/spring/common/dto/ErrorResponse.java
+++ b/spring/src/main/java/org/sopt/spring/common/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package org.sopt.spring.common.dto;
+
+public record ErrorResponse(
+        int status,
+        String message
+) {
+    public static ErrorResponse of(int status, String message) {
+        return new ErrorResponse(status, message);
+    }
+
+    public static ErrorResponse of(ErrorMessage errorMessage) {
+        return new ErrorResponse(errorMessage.getStatus(), errorMessage.getMessage());
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/common/dto/SuccessMessage.java
+++ b/spring/src/main/java/org/sopt/spring/common/dto/SuccessMessage.java
@@ -1,0 +1,15 @@
+package org.sopt.spring.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum SuccessMessage {
+
+    BLOG_CREATE_SUCCESS(HttpStatus.CREATED.value(), "블로그 생성이 완료되었습니다"),
+    ;
+    private final int status;
+    private final String message;
+}

--- a/spring/src/main/java/org/sopt/spring/common/dto/SuccessStatusResponse.java
+++ b/spring/src/main/java/org/sopt/spring/common/dto/SuccessStatusResponse.java
@@ -1,0 +1,10 @@
+package org.sopt.spring.common.dto;
+
+public record SuccessStatusResponse(
+        int status,
+        String message
+) {
+    public static SuccessStatusResponse of(SuccessMessage successMessage) {
+        return new SuccessStatusResponse(successMessage.getStatus(), successMessage.getMessage());
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/config/JpaAuditingConfig.java
+++ b/spring/src/main/java/org/sopt/spring/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package org.sopt.spring.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/spring/src/main/java/org/sopt/spring/controller/BlogController.java
+++ b/spring/src/main/java/org/sopt/spring/controller/BlogController.java
@@ -1,0 +1,39 @@
+package org.sopt.spring.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.spring.common.dto.SuccessMessage;
+import org.sopt.spring.common.dto.SuccessStatusResponse;
+import org.sopt.spring.service.BlogService;
+import org.sopt.spring.service.dto.BlogCreateRequest;
+import org.sopt.spring.service.dto.BlogTitleUpdateRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class BlogController {
+    private final BlogService blogService;
+
+    @PostMapping("/blog")
+    public ResponseEntity<SuccessStatusResponse> createBlog(
+            @RequestHeader Long memberId,
+            @RequestBody BlogCreateRequest blogCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED).header(
+                "Location", blogService.create(memberId, blogCreateRequest))
+                .body(SuccessStatusResponse.of(SuccessMessage.BLOG_CREATE_SUCCESS));
+    }
+    @PatchMapping("/blog/{blogId}/title")
+    public ResponseEntity updateBlogTitle(
+            @PathVariable Long blogId,
+            @Valid @RequestBody BlogTitleUpdateRequest blogTitleUpdateRequest
+    ){
+        blogService.updateTitle(blogId, blogTitleUpdateRequest);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/spring/src/main/java/org/sopt/spring/controller/MemberController.java
+++ b/spring/src/main/java/org/sopt/spring/controller/MemberController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;

--- a/spring/src/main/java/org/sopt/spring/controller/MemberController.java
+++ b/spring/src/main/java/org/sopt/spring/controller/MemberController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,4 +44,9 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/all")
+    public ResponseEntity<List<MemberFindDto>> findAllMembers() {
+        List<MemberFindDto> members = memberService.findAllMembers();
+        return ResponseEntity.ok(members);
+    }
 }

--- a/spring/src/main/java/org/sopt/spring/domain/BaseTimeEntity.java
+++ b/spring/src/main/java/org/sopt/spring/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package org.sopt.spring.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/spring/src/main/java/org/sopt/spring/domain/Blog.java
+++ b/spring/src/main/java/org/sopt/spring/domain/Blog.java
@@ -1,0 +1,40 @@
+package org.sopt.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.spring.service.dto.BlogCreateRequest;
+import org.sopt.spring.service.dto.BlogTitleUpdateRequest;
+import org.springframework.context.annotation.Configuration;
+
+@Entity
+@Getter
+@NoArgsConstructor
+
+public class Blog extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @Column(length = 200)
+    private String title;
+
+    private String description;
+
+    private Blog(Member member, String title, String description) {
+        this.member = member;
+        this.title = title;
+        this.description = description;
+    }
+
+    public static Blog create(Member member, BlogCreateRequest blogCreateRequest) {
+        return new Blog(member, blogCreateRequest.title(), blogCreateRequest.description());
+    }
+    public void updateBlogTitle(BlogTitleUpdateRequest blogTitleUpdateRequest){
+        this.title = blogTitleUpdateRequest.title();
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/domain/Member.java
+++ b/spring/src/main/java/org/sopt/spring/domain/Member.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 public class Member {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/spring/src/main/java/org/sopt/spring/domain/Post.java
+++ b/spring/src/main/java/org/sopt/spring/domain/Post.java
@@ -1,0 +1,21 @@
+package org.sopt.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Post extends BaseTimeEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Blog blog;
+}

--- a/spring/src/main/java/org/sopt/spring/exception/BusinessException.java
+++ b/spring/src/main/java/org/sopt/spring/exception/BusinessException.java
@@ -1,0 +1,12 @@
+package org.sopt.spring.exception;
+
+import org.sopt.spring.common.dto.ErrorMessage;
+
+public class BusinessException extends RuntimeException {
+    private ErrorMessage errorMessage;
+
+    public BusinessException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/exception/NotFoundException.java
+++ b/spring/src/main/java/org/sopt/spring/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package org.sopt.spring.exception;
+
+import org.sopt.spring.common.dto.ErrorMessage;
+
+public class NotFoundException extends BusinessException{
+    public NotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/repository/BlogRepository.java
+++ b/spring/src/main/java/org/sopt/spring/repository/BlogRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.spring.repository;
+
+import org.sopt.spring.domain.Blog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogRepository extends JpaRepository<Blog, Long> {
+}

--- a/spring/src/main/java/org/sopt/spring/service/BlogService.java
+++ b/spring/src/main/java/org/sopt/spring/service/BlogService.java
@@ -1,0 +1,36 @@
+package org.sopt.spring.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.sopt.spring.common.dto.ErrorMessage;
+import org.sopt.spring.domain.Blog;
+import org.sopt.spring.domain.Member;
+import org.sopt.spring.exception.NotFoundException;
+import org.sopt.spring.repository.BlogRepository;
+import org.sopt.spring.service.dto.BlogCreateRequest;
+import org.sopt.spring.service.dto.BlogTitleUpdateRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BlogService {
+    private final BlogRepository blogRepository;
+    private final MemberService memberService;
+
+    public String create(Long memberId, BlogCreateRequest blogCreateRequest) {
+        Member member = memberService.findById(memberId);
+        Blog blog = blogRepository.save(Blog.create(member, blogCreateRequest));
+        return blog.getId().toString();
+    }
+
+    private Blog findByBlogId(Long blogId){
+        return blogRepository.findById(blogId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.BLOG_NOT_FOUND));
+    }
+    @Transactional
+    public void updateTitle(Long blogId, BlogTitleUpdateRequest blogTitleUpdateRequest) {
+        Blog blog = findByBlogId(blogId);
+        blog.updateBlogTitle(blogTitleUpdateRequest);
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/service/MemberService.java
+++ b/spring/src/main/java/org/sopt/spring/service/MemberService.java
@@ -9,6 +9,9 @@ import org.sopt.spring.service.dto.MemberFindDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -35,5 +38,12 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("ID에 해당하는 사용자가 존재하지 않습니다."));
         memberRepository.delete(member);
+    }
+
+    public List<MemberFindDto> findAllMembers() {
+        List<Member> members = memberRepository.findAll();
+        return members.stream()
+                .map(MemberFindDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/spring/src/main/java/org/sopt/spring/service/MemberService.java
+++ b/spring/src/main/java/org/sopt/spring/service/MemberService.java
@@ -2,7 +2,9 @@ package org.sopt.spring.service;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.sopt.spring.common.dto.ErrorMessage;
 import org.sopt.spring.domain.Member;
+import org.sopt.spring.exception.NotFoundException;
 import org.sopt.spring.repository.MemberRepository;
 import org.sopt.spring.service.dto.MemberCreateDto;
 import org.sopt.spring.service.dto.MemberFindDto;
@@ -45,5 +47,11 @@ public class MemberService {
         return members.stream()
                 .map(MemberFindDto::of)
                 .collect(Collectors.toList());
+    }
+
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
+        );
     }
 }

--- a/spring/src/main/java/org/sopt/spring/service/dto/BlogCreateRequest.java
+++ b/spring/src/main/java/org/sopt/spring/service/dto/BlogCreateRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.spring.service.dto;
+
+public record BlogCreateRequest(
+        String title,
+        String description
+) {
+}

--- a/spring/src/main/java/org/sopt/spring/service/dto/BlogTitleUpdateRequest.java
+++ b/spring/src/main/java/org/sopt/spring/service/dto/BlogTitleUpdateRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.spring.service.dto;
+
+import jakarta.validation.constraints.Size;
+
+public record BlogTitleUpdateRequest(
+        @Size(max = 10, message = "블로그 제목이 최대 글자수(10자)를 초과하였습니다")
+        String title
+) {
+}

--- a/spring/src/test/java/org/sopt/spring/controller/BlogControllerTest.java
+++ b/spring/src/test/java/org/sopt/spring/controller/BlogControllerTest.java
@@ -1,0 +1,60 @@
+package org.sopt.spring.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.sopt.spring.repository.BlogRepository;
+import org.sopt.spring.repository.MemberRepository;
+import org.sopt.spring.service.BlogService;
+import org.sopt.spring.service.MemberService;
+import org.sopt.spring.service.dto.BlogCreateRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(BlogController.class)
+@AutoConfigureMockMvc
+public class BlogControllerTest  {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @SpyBean
+    private BlogService blogService;
+
+    @SpyBean
+    private MemberService memberService;
+
+    @MockBean
+    private BlogRepository blogRepository;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Nested
+    class createBlog{
+        @Test
+        @DisplayName("Blog 생성 실패 테스트")
+        public void createBlogFail() throws Exception{
+            //given
+            String request = objectMapper.writeValueAsString(new BlogCreateRequest("석범쓰 블로그", "블로그임"));
+            mockMvc.perform(
+                    post("/api/v1/blog")
+                            .content(request).header("memberId", 3).contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isNotFound())
+                    .andDo(print());
+        }
+    }
+}


### PR DESCRIPTION
# 추가한 부분
멤버 컨트롤러에 멤버 전체를 조회할 수 있는 요청을 받을 Get 매핑 컨트롤러를 추가했습니다.
멤버 서비스에 이에 맞는 findAllMembers라는 함수를 추가해줬습니다.
나머지는 기존 코드를 그대로 사용했습니다.
# MemberController
```java
@GetMapping("/all")
    public ResponseEntity<List<MemberFindDto>> findAllMembers() {
        List<MemberFindDto> members = memberService.findAllMembers();
        return ResponseEntity.ok(members);
    }
```
기존 url에 all을 붙히면 전체 멤버를 리스트로 반환해주는 컨트롤러입니다.
다른 컨트롤러와 동일하게 ResponseEntity를 반환값으로 사용해주었습니다.
멤버 한명을 조회하는 컨트롤러와 다른 점은 ResponseEntity의 ok함수에 인자로 MemberFindDto 리스트를 넣어주었습니다.

# MemberService
```java
public List<MemberFindDto> findAllMembers() {
        List<Member> members = memberRepository.findAll();
        return members.stream()
                .map(MemberFindDto::of)
                .collect(Collectors.toList());
    }
```
JPA의 findAll() 함수를 이용하여 Member 객체 리스트를 생성해주었습니다.
그 후 stream의 map함수와 collect를 이용하여 리스트로 반환해주었습니다.

# API 명세서
https://faint-grenadilla-bdc.notion.site/aeee9d67f0c4446b80feed3b62ed31e7?v=5d40ad868d8a44d592b679d526ebf2b0&pvs=4

# 궁금한 점
구글링을 해보니 리스트 반환 로직을 대부분 stream을 이용하여 작성해주는데 java8 이후부터는 이 방법이 정석처럼 널리 사용되는 것인가요?