### PR TITLE
[week6] 6차 세미나 정규 과제

### DIFF
--- a/.idea/sukbum.iml
+++ b/.idea/sukbum.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_17_PREVIEW" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$" />
     <orderEntry type="inheritedJdk" />

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	//Multipart file
 	implementation("software.amazon.awssdk:bom:2.21.0")
 	implementation("software.amazon.awssdk:s3:2.21.0")
+
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.3.1.RELEASE'
 }
 
 tasks.named('test') {

--- a/spring/src/main/java/org/sopt/spring/common/auth/SecurityConfig.java
+++ b/spring/src/main/java/org/sopt/spring/common/auth/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member"};
+    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member", "/api/v1/member/refresh"};
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/spring/src/main/java/org/sopt/spring/common/auth/SecurityConfig.java
+++ b/spring/src/main/java/org/sopt/spring/common/auth/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member", "/api/v1/member/refresh"};
+    private static final String[] AUTH_WHITE_LIST = {"/api/v1/member"};
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/spring/src/main/java/org/sopt/spring/common/auth/redis/config/RedisConfig.java
+++ b/spring/src/main/java/org/sopt/spring/common/auth/redis/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package org.sopt.spring.common.auth.redis.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/common/auth/redis/domain/Token.java
+++ b/spring/src/main/java/org/sopt/spring/common/auth/redis/domain/Token.java
@@ -1,0 +1,31 @@
+package org.sopt.spring.common.auth.redis.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@RedisHash(value = "", timeToLive = 60 * 60 * 24 * 1000L * 14)
+@AllArgsConstructor
+@Getter
+@Builder
+public class Token {
+
+    @Id
+    private Long id;
+
+    @Indexed
+    private String refreshToken;
+
+    public static Token of(
+            final Long id,
+            final String refreshToken
+    ) {
+        return Token.builder()
+                .id(id)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/spring/src/main/java/org/sopt/spring/common/auth/redis/repository/RedisTokenRepository.java
+++ b/spring/src/main/java/org/sopt/spring/common/auth/redis/repository/RedisTokenRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.spring.common.auth.redis.repository;
+
+import org.sopt.spring.common.auth.redis.domain.Token;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RedisTokenRepository extends CrudRepository<Token, String> {
+    Optional<Token> findByRefreshToken(final String refreshToken);
+    Optional<Token> findById(final Long id);
+}

--- a/spring/src/main/java/org/sopt/spring/common/exception/ErrorMessage.java
+++ b/spring/src/main/java/org/sopt/spring/common/exception/ErrorMessage.java
@@ -12,6 +12,7 @@ public enum ErrorMessage {
     BLOG_CANT_USE(HttpStatus.NOT_FOUND.value(), "사용자의 블로그가 아닙니다."),
     POSTING_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다"),
     JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "사용자의 로그인 검증을 실패했습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED.value(), "리프레시 토큰이 만료되었습니다."),
     ;
     private final int status;
     private final String message;

--- a/spring/src/main/java/org/sopt/spring/common/jwt/JwtTokenProvider.java
+++ b/spring/src/main/java/org/sopt/spring/common/jwt/JwtTokenProvider.java
@@ -17,7 +17,8 @@ public class JwtTokenProvider {
 
     private static final String USER_ID = "userId";
 
-    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L;
+    private static final Long REFRESH_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
 
     @Value("${jwt.secret}")
     private String JWT_SECRET;
@@ -25,6 +26,9 @@ public class JwtTokenProvider {
 
     public String issueAccessToken(final Authentication authentication) {
         return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+    public String issueRefreshToken(final Authentication authentication) {
+        return generateToken(authentication, REFRESH_TOKEN_EXPIRATION_TIME);
     }
 
 
@@ -42,6 +46,7 @@ public class JwtTokenProvider {
                 .signWith(getSigningKey()) // Signature
                 .compact();
     }
+
 
     private SecretKey getSigningKey() {
         String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성

--- a/spring/src/main/java/org/sopt/spring/member/controller/MemberController.java
+++ b/spring/src/main/java/org/sopt/spring/member/controller/MemberController.java
@@ -36,6 +36,15 @@ public class MemberController {
                         userJoinResponse
                 );
     }
+    @PostMapping("/refresh")
+    public ResponseEntity<UserJoinResponse> refreshAccessToken() {
+        UserJoinResponse userJoinResponse = memberService.createMember(memberCreateDto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", userJoinResponse.userId())
+                .body(
+                        userJoinResponse
+                );
+    }
 
     @GetMapping("/{memberId}")
     public ResponseEntity<MemberFindDto> findMemberById(@PathVariable Long memberId) {
@@ -43,7 +52,9 @@ public class MemberController {
     }
 
     @DeleteMapping("/{memberId}")
-    public ResponseEntity deleteMemberById(@PathVariable Long memberId){
+    public ResponseEntity deleteMemberById(
+            @PathVariable Long memberId
+    ){
         memberService.deleteMemberById(memberId);
         return ResponseEntity.noContent().build();
     }

--- a/spring/src/main/java/org/sopt/spring/member/controller/MemberController.java
+++ b/spring/src/main/java/org/sopt/spring/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package org.sopt.spring.member.controller;
 
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.spring.common.auth.PrincipalHandler;
 import org.sopt.spring.member.service.MemberService;
 import org.sopt.spring.member.dto.MemberCreateDto;
 import org.sopt.spring.member.dto.MemberFindDto;
@@ -24,6 +25,7 @@ import java.util.List;
 public class MemberController {
 
     private final MemberService memberService;
+    private final PrincipalHandler principalHandler;
 
     @PostMapping
     public ResponseEntity<UserJoinResponse> createMember(
@@ -36,9 +38,12 @@ public class MemberController {
                         userJoinResponse
                 );
     }
+
     @PostMapping("/refresh")
-    public ResponseEntity<UserJoinResponse> refreshAccessToken() {
-        UserJoinResponse userJoinResponse = memberService.createMember(memberCreateDto);
+    public ResponseEntity<UserJoinResponse> refreshToken(){
+        UserJoinResponse userJoinResponse = memberService.refreshToken(
+                principalHandler.getUserIdFromPrincipal()
+        );
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header("Location", userJoinResponse.userId())
                 .body(

--- a/spring/src/main/java/org/sopt/spring/member/controller/MemberController.java
+++ b/spring/src/main/java/org/sopt/spring/member/controller/MemberController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
 import java.util.List;
 
 @RestController

--- a/spring/src/main/java/org/sopt/spring/member/service/dto/UserJoinResponse.java
+++ b/spring/src/main/java/org/sopt/spring/member/service/dto/UserJoinResponse.java
@@ -2,14 +2,16 @@ package org.sopt.spring.member.service.dto;
 
 public record UserJoinResponse(
         String accessToken,
+        String refreshToken,
         String userId
 ) {
 
     public static UserJoinResponse of(
             String accessToken,
+            String refreshToken,
             String userId
     ) {
-        return new UserJoinResponse(accessToken, userId);
+        return new UserJoinResponse(accessToken, refreshToken, userId);
     }
 }
 


### PR DESCRIPTION
# 과제TODO
* 로그인을 진행할 때 AccessToken과. RefreshToken을 함께 반환하는 로직 구현
* Redis를 활용해 RefreshToken으로 AccessToken을 재발급 받는 로직 구현
# 구현사항
## 로그인 시 RefreshToken도 같이 발급
* 멤버가입 반환 DTO에  Refresh Token 추가
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/member/service/dto/UserJoinResponse.java#L3-L16

* AccessToken 만료시간 줄임, RefreshToken 발급 로직 추가
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/common/jwt/JwtTokenProvider.java#L20-L32

* Redis 설정파일 추가
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/common/auth/redis/config/RedisConfig.java#L11-L32

* Redis에 RefreshToken 저장을 위한 Token 도메인 추가
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/common/auth/redis/domain/Token.java#L10-L31

* CrudRepository 상속받아서 Redis용 레포지토리 구현
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/common/auth/redis/repository/RedisTokenRepository.java#L8-L11


* AccessToken줄 때 RefreshToken Redis에 저장하고 같이 반환
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/member/service/MemberService.java#L31-L49

## RefreshToken으로 AccessToken 재발급
* 재발급 컨트롤러 구현
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/member/controller/MemberController.java#L42-L52

* 재발급 서비스 구현
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/member/service/MemberService.java#L77-L96

# 질문하고 싶은거!!
1. Refresh 토큰 또한 JWT 토큰이기 때문에 Access 토큰과 동일하게 JWT 검증 필터를 거치게 했습니다.
때문에 별도의 Refresh 토큰 검증 없이 (어차피 필터에서 다 해주니깐) PricipalHandler를 통해 memberId만 똑 떼와서 Redis에 해당 키값으로 Refresh 토큰이 있는지 (만료 시간 지나면 없을테니깐) 확인만 해주었는데 괜찮은 방법일까요?

2. Redis는 동일 키값에 대해서 또 저장하면 덮어씌운다길래 기존 Refresh 토큰을 지우는 로직은 뺐는데 확실하게 해주기 위해 지우는 로직도 추가해야 할까요?

3. Refresh 토큰을 통해 Access 토큰만 계속 재발급해주면 Access 토큰보다 만료시간이 짧아질 수 있다고 생각해서 항상 Refreh 토큰도 새로 만들었는데 괜찮은 방식일까요?

4. SecurityConfig에서 /refresh 엔드포인트를 화이트리스트에 넣어줘도 계속 JWT 필터를 거치던데 정말 왜그런지 모르겠습니다..
https://github.com/NOW-SOPT-SERVER/sukbum/blob/f3e6f5369f780f5457498c710d958382077de0aa/spring/src/main/java/org/sopt/spring/common/auth/SecurityConfig.java#L24-L45